### PR TITLE
Passing keyword arguments to delete_variable

### DIFF
--- a/src/firmware_variables/variables.py
+++ b/src/firmware_variables/variables.py
@@ -85,4 +85,4 @@ def delete_variable(name, *args, **kwargs):
     :param namespace: Guid of the form {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
     :param attributes: @see Attributes
     """
-    set_variable(name, value=b"", **kwargs)
+    set_variable(name, value=b"", *args, **kwargs)

--- a/src/firmware_variables/variables.py
+++ b/src/firmware_variables/variables.py
@@ -78,7 +78,7 @@ def set_variable(name, value, namespace=GLOBAL_NAMESPACE, attributes=DEFAULT_ATT
         raise WinError()
 
 
-def delete_variable(name, **kwargs):
+def delete_variable(name, *args, **kwargs):
     """
     Delete the UEFI variable
     :param name: Variable name

--- a/src/firmware_variables/variables.py
+++ b/src/firmware_variables/variables.py
@@ -78,11 +78,11 @@ def set_variable(name, value, namespace=GLOBAL_NAMESPACE, attributes=DEFAULT_ATT
         raise WinError()
 
 
-def delete_variable(name, *args):
+def delete_variable(name, **kwargs):
     """
     Delete the UEFI variable
     :param name: Variable name
     :param namespace: Guid of the form {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
     :param attributes: @see Attributes
     """
-    set_variable(name, value=b"", *args)
+    set_variable(name, value=b"", **kwargs)


### PR DESCRIPTION
Swapped `*args` with `**kwargs` for `delete_variable` to allow calling it with `set_variable`'s keyword arguments

closes #5 