### PR TITLE
Bugfix/python27 dependencies and wrong types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,16 @@ from setuptools import setup
 
 setup(
     name='firmware_variables',
-    version='0.0.4',
+    version='0.0.5',
     description='Windows library for controlling UEFI firmware variables',
     author='Netanel Dziubov',
     packages=['firmware_variables'],
     package_dir={'': 'src'},
-    install_requires=['pywin32', 'aenum'],
+    install_requires=[
+        'pywin32', 
+        'aenum', 
+        'enum34; python_version < "3"',
+    ],
     url="https://github.com/netaneld122/firmware-variables",
     python_requires='>=2.7',
     classifiers=[

--- a/src/firmware_variables/variables.py
+++ b/src/firmware_variables/variables.py
@@ -49,7 +49,7 @@ def get_variable(name, namespace=GLOBAL_NAMESPACE):
             pointer(attributes))
 
         if stored_bytes != 0:
-            return buffer.raw[:stored_bytes], Attributes(attributes.value)
+            return buffer.raw[:stored_bytes], Attributes(int(attributes.value))
         elif gle() == ERROR_BUFFER_TOO_SMALL:
             allocation *= 2
         else:


### PR DESCRIPTION
- Add missing `enum34` dependency for python2.7
- Convert returned `long` type to `int` to avoid `TypeError`